### PR TITLE
fix edit-page link stub

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -9,7 +9,7 @@ const config: DocsThemeConfig = {
   chat: {
     link: 'https://discord.gg/QcD3wWSp',
   },
-  docsRepositoryBase: 'https://github.com/ethereum/portal-network-specs/tree/master',
+  docsRepositoryBase: 'https://github.com/ethereum/portal-website/tree/master',
   footer: {
     text: 'Portal Network docs',
   }

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -9,7 +9,7 @@ const config: DocsThemeConfig = {
   chat: {
     link: 'https://discord.gg/QcD3wWSp',
   },
-  docsRepositoryBase: 'https://github.com/ethereum/portal-network-specs',
+  docsRepositoryBase: 'https://github.com/ethereum/portal-network-specs/tree/master',
   footer: {
     text: 'Portal Network docs',
   }


### PR DESCRIPTION
updates link stub used to generate Github links for "edit this page" 