### PR TITLE
add new section for "clients" + landing page

### DIFF
--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -2,6 +2,7 @@
         "index": "Home",
         "overview": "Overview",
         "resources": "Resources",
+        "clients": "Clients",
         "community": "Community",
         "faq": "FAQ",
         "blog": "Blog"

--- a/pages/clients.mdx
+++ b/pages/clients.mdx
@@ -1,0 +1,28 @@
+# Portal Network clients
+
+There are three Portal Network clients being developed in parallel: Trin, Ultralight and Fluffy.
+
+## Why build three clients?
+
+Client diversity is a major source of strength for Ethereum. It means that a bug, or an exploit in one client doesn't bring down the entire network, because the chance that the same problem is replicated in multiple idnependently developed clients is small. For Ethereum execution and consensus clients, a healthy diversity of clients has been challenging to achieve. Part of the reason for this is because there has long been a "main" execution client and others created later, but the network effects of the original client have been very difficult to overcome. The Portal Network developers are trying to frontrun this problem by having three clients right from the start.
+
+It is also possible for clients to specialize as they develop, so they can serve slightly different sets of users. For example, one client might favour absolutely minimizing the hardware and computational requirements, while another might aim to be the most fully featured.
+
+## What do the clients do?
+
+Portal clients are software that turn a computer into a Portal node. The cleint software allows a node to connect to other Portal nodes, forming a peer-to-peer network. Clients act as an interface to the network. They enable users to request data. A request passes across the network until it reaches a node that can serve the relevant response. In this way, Portal clients give people access to the Portal Network.
+
+Because each node only stores a small amount of the total data, they do not require special hardware and do not consume much memory or CPU. However, in aggregate the network itself can store a huge volume of data, permanently in a decentralized way.
+
+## Which client should I use?
+
+Whichever you like! However, you should know that all three clients are currently in development and have not had a production release. The whole network is currently experimental and is currently missing some data. That said, you are welcome to become an early adopter! pick a client, download and install, and start experimenting with us!
+
+
+## More information
+
+Explore the dedicated pages for each client:
+
+- [Trin](trin.md)
+- [Fluffy](fluffy.md)
+- [Ultralight](ultralight.md)

--- a/pages/clients.mdx
+++ b/pages/clients.mdx
@@ -18,6 +18,9 @@ Because each node only stores a small amount of the total data, they do not requ
 
 Whichever you like! However, you should know that all three clients are currently in development and have not had a production release. The whole network is currently experimental and is currently missing some data. That said, you are welcome to become an early adopter! pick a client, download and install, and start experimenting with us!
 
+## What are bridge nodes?
+
+Bridge nodes are a special type of Portal Network node that grab information from Ethereum and push it into the Portal Network. Without bridge nodes, Portal Network would not have a connection to Ethereum, so it would not be able to provide up-to-date Ethereum data. Bridge nodes need a connection to an Ethereum full node.
 
 ## More information
 
@@ -26,3 +29,4 @@ Explore the dedicated pages for each client:
 - [Trin](trin.md)
 - [Fluffy](fluffy.md)
 - [Ultralight](ultralight.md)
+- [Bridge Nodes](bridge-nodes.md)

--- a/pages/clients/bridge-nodes.md
+++ b/pages/clients/bridge-nodes.md
@@ -1,0 +1,14 @@
+# Bridge Nodes
+
+## What is a bridge node?
+
+Bridge nodes push data from Ethereum into the Portal Network. They need a connection to an Ethereum full node.
+
+## Why run a bridge node?
+
+The Portal Network is in development. One of the easiest ways to contribute is to help pump data from Ethereum into the Portal Network.
+The way you would do this is by running a bridge node. The more people that run bridge nodes, the faster Portal Network will be able to serve Ethereum's historical data and you can start using and building on top of super lightweight clients.
+
+## How to run a bridge node
+
+...tbc

--- a/pages/clients/fluffy.md
+++ b/pages/clients/fluffy.md
@@ -1,0 +1,23 @@
+# Fluffy
+
+Fluffy is an implementation of a [Portal Network client](https://github.com/ethereum/portal-network-specs) written in [Nim](https://nim-lang.org/).
+
+You would use Fluffy to interact with the Portal Network. This gives access to Ethereum data with very low CPU and memory requirements and near instant sync.
+
+Fluffy is still in active developmenmt - it is not ready for production use!
+
+
+## Get Fluffy
+
+You can download Fluffy from the [project Github](https://github.com/status-im/nimbus-eth1/tree/master/fluffy).
+
+
+## Fluffy documentation
+
+You can read the notes in the [Github README](https://github.com/status-im/nimbus-eth1/tree/master/fluffy)!
+
+There you will find instructions for installing, running and interacting with Fluffy for your operating system.
+
+## Keep up
+
+Monthly development updates are made available on the project [HackMD](https://hackmd.io/jRpxY4WBQJ-hnsKaPDYqTw).

--- a/pages/clients/trin.md
+++ b/pages/clients/trin.md
@@ -1,0 +1,19 @@
+# Trin
+
+Trin is an implementation of a [Portal Network client](https://github.com/ethereum/portal-network-specs) written in [Rust](https://www.rust-lang.org/).
+
+You would use Trin to interact with the Portal Network. This gives access to Ethereum data with very low CPU and memory requirements and near instant sync.
+
+Trin is still in active developmenmt - it is not ready for production use!
+
+
+## Get Trin
+
+You can download Trin from the [project Github](https://github.com/ethereum/trin/tree/master).
+
+
+## Trin documentation
+
+You can read the [Trin book](https://ethereum.github.io/trin/)!
+
+There you will find instructions for installing, running and interacting with Trin for your operating system.

--- a/pages/clients/ultralight.md
+++ b/pages/clients/ultralight.md
@@ -1,0 +1,19 @@
+# Ultralight
+
+Ultralight is an implementation of a [Portal Network client](https://github.com/ethereum/portal-network-specs) written in [Typescript](https://www.typescriptlang.org/).
+
+You would use Ultralight to interact with the Portal Network. This gives access to Ethereum data with very low CPU and memory requirements and near instant sync.
+
+Ultralight is still in active developmenmt - it is not ready for production use!
+
+
+## Get Ultralight
+
+You can download Ultralight from the [project Github](https://github.com/ethereumjs/ultralight/tree/master).
+
+
+## Ultralight documentation
+
+You can read the notes in the [Github README](https://github.com/ethereumjs/ultralight/tree/master)!
+
+There you will find instructions for installing, running and interacting with Ultralight for your operating system.


### PR DESCRIPTION
Adds section on PN clients, with a landing page plus individual pages for basic information about each client.
This should be considered an MVP, with the expectation that client teams can add detail later.

p.s. also adds page on bridge nodes (super low detail at the moment but can be fleshed out retroactively)