### PR TITLE
Updating team.mdx page

### DIFF
--- a/pages/community/team.mdx
+++ b/pages/community/team.mdx
@@ -9,16 +9,15 @@
 [Nick Gheorghita](https://github.com/njgheorghita)
 - Full-time developer on Trin client
 
-[Jacob Kaufmann](https://github.com/jacobkaufmann)
-- Apprenticeship Program
-- Full-time developer on Trin client
-- Major specification contributions
-
 [Ognyan Genev](https://github.com/ogenev)
 - Apprenticeship Program
 - Full-time developer on Trin client
 
 [Mike Ferris](https://github.com/mrferris)
+- Apprenticeship Program
+- Full-time developer on Trin client
+
+[Kolby ML (Moroz Liebl)](https://github.com/KolbyML)
 - Apprenticeship Program
 - Full-time developer on Trin client
 
@@ -38,11 +37,23 @@
 - Protocol development
 - Contributions to specifications
 
-[Konrad Staniec](https://github.com/KonradStaniec)
+[Daniel Sobol](https://github.com/mynameisdaniil)
 - Full-time developer on Fluffy client
-- Minor contributions to specifications
 
 ## 3rd Party
+
+[Jacob Kaufmann](https://github.com/jacobkaufmann)
+- Apprenticeship Program
+- Contributor to Trin client
+- Major specification contributions
+
+[Konrad Staniec](https://github.com/KonradStaniec)
+- Contributor to Fluffy client
+- Minor contributions to specifications
+
+[Perama](https://github.com/perama-v)
+- Contributor to Trin client
+- Contributor to Glados
 
 [Keenan Nemetz](https://github.com/nasdf)
 - Apprenticeship Program

--- a/pages/community/team.mdx
+++ b/pages/community/team.mdx
@@ -40,7 +40,7 @@
 [Daniel Sobol](https://github.com/mynameisdaniil)
 - Full-time developer on Fluffy client
 
-## 3rd Party
+## Prior Contributors
 
 [Jacob Kaufmann](https://github.com/jacobkaufmann)
 - Apprenticeship Program
@@ -50,6 +50,8 @@
 [Konrad Staniec](https://github.com/KonradStaniec)
 - Contributor to Fluffy client
 - Minor contributions to specifications
+
+## 3rd Party
 
 [Perama](https://github.com/perama-v)
 - Contributor to Trin client


### PR DESCRIPTION
The previous version is fairly old and out dated.

Me and Daniel are now full time of our respective teams.

Jacob changed teams and is now a research at the EF and not full time on Portal/Trin

Konrad changed jobs I remember Kim telling me at Boulder

 Perama Contributed a lot to Glados and Trin so I think he should be on 3rd party