### PR TITLE
Fixed typo in Beacon Network page

### DIFF
--- a/pages/concepts/protocols/portal-sub-protocols/beacon-chain.md
+++ b/pages/concepts/protocols/portal-sub-protocols/beacon-chain.md
@@ -46,4 +46,4 @@ To verify canonicalness of an execution block header older than ~27 hours, we ne
 
 ## Specification
 
-Read the fuill specification for the Beacon network on the [Portal Network Github](https://github.com/ethereum/portal-network-specs/blob/master/beacon-chain/beacon-network.md)
+Read the full specification for the Beacon network on the [Portal Network Github](https://github.com/ethereum/portal-network-specs/blob/master/beacon-chain/beacon-network.md)


### PR DESCRIPTION
Current sentence under *Specification* header reads: *"Read the **fuill** specification for the Beacon network on the Portal Network Github."* Changed to "*Read the **full** specification for the Beacon network on the Portal Network Github."*