### PR TITLE
Update fluffy.md with docs link to fluffy.guide

### DIFF
--- a/pages/clients/fluffy.md
+++ b/pages/clients/fluffy.md
@@ -14,7 +14,7 @@ You can download Fluffy from the [project Github](https://github.com/status-im/n
 
 ## Fluffy documentation
 
-You can read the notes in the [Github README](https://github.com/status-im/nimbus-eth1/tree/master/fluffy)!
+You can read the [Fluffy guide](https://fluffy.guide)!
 
 There you will find instructions for installing, running and interacting with Fluffy for your operating system.
 


### PR DESCRIPTION
All docs have been moved to fluffy.guide since many months, but this didn't get adjusted here.