### PR TITLE
Fixed subprotocols spec links

### DIFF
--- a/pages/concepts/protocols/portal-sub-protocols/history.md
+++ b/pages/concepts/protocols/portal-sub-protocols/history.md
@@ -81,4 +81,4 @@ The network supports the following mechanisms for data retrieval:
 
 ## Specification
 
-You can find the History Network specification on the [Portal Network Github](https://github.com/ethereum/portal-network-specs/blob/master/history-network.md).
+You can find the History Network specification on the [Portal Network Github](https://github.com/ethereum/portal-network-specs/blob/master/history/history-network.md).

--- a/pages/concepts/protocols/portal-sub-protocols/state.md
+++ b/pages/concepts/protocols/portal-sub-protocols/state.md
@@ -27,4 +27,4 @@ The network stores the full execution layer state which encompasses the followin
 
 ## Specification
 
-You can read the full specification on the [Portal Network Github](https://github.com/ethereum/portal-network-specs/blob/master/state-network.md).
+You can read the full specification on the [Portal Network Github](https://github.com/ethereum/portal-network-specs/blob/master/state/state-network.md).


### PR DESCRIPTION
While reading the docs I noticed that state and history subprotocols pages have broken links to the specs.